### PR TITLE
Fixed blank dashboard loading for first time user.

### DIFF
--- a/amplifytassel/cypress/e2e/LoginTest.cy.js
+++ b/amplifytassel/cypress/e2e/LoginTest.cy.js
@@ -9,8 +9,8 @@ describe('Sign In:', () => {
   it('allows a user to signin', () => {
     // Step 2: Take an action (Sign in)
     cy.get(selectors.logInButtonOnLandingPage).contains('Login').click();
-    cy.get(selectors.LoginEmailInput).type("ulekhtsi+1@ucsc.edu");
-    cy.get(selectors.LoginPasswordInput).type("Abcd1234");
+    cy.get(selectors.LoginEmailInput).type("jiqle@ucsc.edu");
+    cy.get(selectors.LoginPasswordInput).type("coolCat2025@");
     cy.get(selectors.LoginButton).contains('Login').click();
 
     cy.wait(4000);

--- a/amplifytassel/src/app/pages/Login.js
+++ b/amplifytassel/src/app/pages/Login.js
@@ -91,6 +91,24 @@ export default function Login() {
   const [isPasswordBad, setIsPasswordBad] = useState(null);
   useEffect(() => setIsPasswordBad(null), [values, stepPage]);
 
+  /* 
+  Initialize data store early for edge case where user logins for first time
+  */
+  useEffect(() => {
+  const initializeDataStore = async () => {
+    try {
+      await DataStore.start(); 
+      await DataStore.observeReady(); 
+      console.log("DataStore is ready! Now safe to query.");
+    } catch (e) {
+      console.error("Error initializing DataStore", e);
+    }
+  };
+
+  // Call the async function
+  initializeDataStore();
+}, []); 
+
   // Called when the user clicks 'Login'
   // 1) If the user's email or password is incorrect, then display an error message
   // 2) If the user's email is not verified, then redirect to the verification page
@@ -101,16 +119,6 @@ export default function Login() {
 
 
 
-    /* 
-    Initialize data store early for edge case where user logins for first time
-    */
-    try {
-      await DataStore.start(); 
-      await DataStore.observeReady(); 
-      console.log("DataStore is ready! Now safe to query.");
-    } catch (e) {
-      console.error("Error initializing DataStore", e);
-    }
 
     Auth.signIn(values["login"].useremail, values["login"].userpassword)
       .then((user) => {

--- a/amplifytassel/src/app/pages/Login.js
+++ b/amplifytassel/src/app/pages/Login.js
@@ -11,6 +11,7 @@ import ThemedInput from "../components/Themed/ThemedInput";
 import LoginBanner from "../assets/sammy-ocean.png";
 import useAuth from "../util/AuthContext";
 import "../stylesheets/LoginSignup.css";
+import { DataStore } from "aws-amplify";
 import { Auth } from "aws-amplify";
 
 const PaperStyling = {
@@ -97,6 +98,20 @@ export default function Login() {
   const login = async () => {
     //const keepLoggedIn = document.getElementById('keepLoggedIn').checked;
     setIsBackendLoading(true);
+
+
+
+    /* 
+    Initialize data store early for edge case where user logins for first time
+    */
+    try {
+      await DataStore.start(); 
+      await DataStore.observeReady(); 
+      console.log("DataStore is ready! Now safe to query.");
+    } catch (e) {
+      console.error("Error initializing DataStore", e);
+    }
+
     Auth.signIn(values["login"].useremail, values["login"].userpassword)
       .then((user) => {
         if (user.challengeName === "NEW_PASSWORD_REQUIRED") {

--- a/amplifytassel/src/app/pages/Login.js
+++ b/amplifytassel/src/app/pages/Login.js
@@ -51,6 +51,7 @@ export default function Login() {
   const { setLoadingAuth } = useAuth();
 
   const [stepPage, setStepPage] = useState("login");
+  const [isDataStoreReady, setIsDataStoreReady] = useState(false);
   const [values, setValues] = useState({
     login: {
       useremail: "",
@@ -98,8 +99,8 @@ export default function Login() {
   const initializeDataStore = async () => {
     try {
       await DataStore.start(); 
-      await DataStore.observeReady(); 
       console.log("DataStore is ready! Now safe to query.");
+      setIsDataStoreReady(true); 
     } catch (e) {
       console.error("Error initializing DataStore", e);
     }

--- a/amplifytassel/src/app/pages/Login.js
+++ b/amplifytassel/src/app/pages/Login.js
@@ -51,7 +51,6 @@ export default function Login() {
   const { setLoadingAuth } = useAuth();
 
   const [stepPage, setStepPage] = useState("login");
-  const [isDataStoreReady, setIsDataStoreReady] = useState(false);
   const [values, setValues] = useState({
     login: {
       useremail: "",
@@ -99,8 +98,7 @@ export default function Login() {
   const initializeDataStore = async () => {
     try {
       await DataStore.start(); 
-      console.log("DataStore is ready! Now safe to query.");
-      setIsDataStoreReady(true); 
+      console.log("DataStore is ready");
     } catch (e) {
       console.error("Error initializing DataStore", e);
     }


### PR DESCRIPTION
Problem:
When the user logs in in a new browser, cleared cache, or removed datastoredb, the dashboard will be empty. This was intially perceived as a problem with browsers that are not chrome but it extends to all browsers with first time user. This happens because when the user logins they are redirected to dashboard page where information is retrieved from datastore. However by the time user logins for first time, datastore is not initialized yet leading to instance where a user is able to login before they are able to retrieve information.

Fix:
The fix was calling datastore to start when login page is brought up for first time that way there is no racetime conditon between logging in and waiting for datastore to initialize before user is brought to dashboard page. This also fixes many test cases failing as many would fail due to bringing up a blank dashboard page with no loaded user information. 

Other Notes:
I modified a test to include one of the more current admin accounts and it is able to pass successfully. Some admin account in the test database appear to not be up to date.