### PR TITLE
remove username requirement when updating profile

### DIFF
--- a/amplifytassel/src/app/pages/UpdateProfile.js
+++ b/amplifytassel/src/app/pages/UpdateProfile.js
@@ -375,13 +375,7 @@ export default function UpdateProfile() {
   const handleSubmit = async (e) => {
     e.preventDefault(); // Prevent the default form behavior
 
-    // Validate required fields
-    if (!values[1].username.trim()) {
-      toast.error(`Username is required`, toastOptions);
-      return;
-    }
-
-    if (values[1].username.length > 20) {
+    if (values[1].username && values[1].username.length > 20) {
       toast.error(`Username is too long`, toastOptions);
       return;
     }


### PR DESCRIPTION
If you try to save changes to your profile for the first time without entering a username, the save will fail with no error indicating why. I removed the need to enter a username to make things less confusing for new users, and because usernames currently serve no purpose.