### PR TITLE
add participant count chips to opp cards

### DIFF
--- a/amplifytassel/src/app/components/Dashboard/DashboardOppThumbnail.js
+++ b/amplifytassel/src/app/components/Dashboard/DashboardOppThumbnail.js
@@ -4,13 +4,16 @@ import { styled } from "@mui/material/styles";
 import CardActionArea from "@mui/material/CardActionArea";
 import { Storage } from "aws-amplify";
 import { Card, CardContent, CardMedia, Typography, Box } from "@mui/material";
+import Chip from "@mui/material/Chip";
 import FmdGoodOutlinedIcon from "@mui/icons-material/FmdGoodOutlined";
 import DevicesOutlinedIcon from "@mui/icons-material/DevicesOutlined";
 import AccessibilityRoundedIcon from "@mui/icons-material/AccessibilityRounded";
 import EventNoteRoundedIcon from "@mui/icons-material/EventNoteRounded";
+import PeopleIcon from "@mui/icons-material/People";
 
 const CustomCard = ({ opportunity }) => {
   const [banner, setBanner] = useState(null);
+  const [participants, setParticipants] = useState(0);
 
   const downloadFile = async () => {
     const img = await Storage.get(opportunity.bannerKey, {
@@ -22,6 +25,15 @@ const CustomCard = ({ opportunity }) => {
   useEffect(() => {
     downloadFile();
   }, []);
+
+  useEffect(() => {
+    if (opportunity?.profilesJoined?.values) {
+      opportunity.profilesJoined.values
+        .then((result) => {
+          setParticipants(result.length);
+        })
+    }
+  }, [opportunity]);
 
   const formatDate = (startTime) => {
     const dateOptions = {
@@ -75,10 +87,13 @@ const CustomCard = ({ opportunity }) => {
             variant="h6"
             component="div"
             className="title-margin"
-            gutterBottom
           >
             <p className="text-dark text-xbold">{opportunity.eventName}</p>
           </Typography>
+
+          <Box sx={{ display: "inline-flex", marginBottom: "5px" }}>
+            <Chip label={participants} icon={<PeopleIcon />} size="small" />
+          </Box>          
           {/* Subtitle or Extra Information */}
           <Typography
             variant="body2"

--- a/amplifytassel/src/app/components/Dashboard/DashboardPendingOppCard.js
+++ b/amplifytassel/src/app/components/Dashboard/DashboardPendingOppCard.js
@@ -6,6 +6,7 @@ import {
   Box,
   ListItem,
 } from "@mui/material";
+import Chip from "@mui/material/Chip";
 import { useNavigate } from "react-router-dom";
 import { DataStore, Storage } from "aws-amplify";
 import { Request } from "../../../models";
@@ -13,10 +14,12 @@ import MuiBox from "@mui/material/Box";
 import { Grid } from "@mui/material";
 import EventNoteRoundedIcon from "@mui/icons-material/EventNoteRounded";
 import AccessibilityRoundedIcon from "@mui/icons-material/AccessibilityRounded";
+import PeopleIcon from "@mui/icons-material/People";
 
 export default function DashboardPendingOppCard({ opportunity }) {
   const [requests, setRequests] = useState([]);
   const [banner, setBanner] = useState(null);
+  const [participants, setParticipants] = useState(0);
   const navigate = useNavigate();
 
   const navigateToOpp = (oppid) => {
@@ -47,6 +50,12 @@ export default function DashboardPendingOppCard({ opportunity }) {
     setRequests([]);
     getPendingRequestsReceived();
     downloadFile();
+    if (opportunity?.profilesJoined?.values) {
+      opportunity.profilesJoined.values
+        .then((result) => {
+          setParticipants(result.length);
+        })
+    }
   }, [opportunity]);
 
   const formatDate = (date) => {
@@ -174,13 +183,16 @@ export default function DashboardPendingOppCard({ opportunity }) {
             height: "100%",
           }}
         >
-          <Typography
-            variant="body1"
-            fontWeight="bold"
-            sx={{ color: "var(--text-dark)" }}
-          >
-            {opportunity?.eventName}
-          </Typography>
+          <MuiBox sx={{ display: "flex" }}>
+            <Typography
+              variant="body1"
+              fontWeight="bold"
+              sx={{ color: "var(--text-dark)", marginRight: "10px" }}
+            >
+              {opportunity?.eventName}
+            </Typography>
+            <Chip label={participants} icon={<PeopleIcon />} size="small" />
+          </MuiBox>
           <Typography variant="body2" color="var(--text-gray)">
             <div className="flex-horizontal flex-flow-large flex-align-center">
               <EventNoteRoundedIcon sx={{ fontSize: "0.9rem" }} />

--- a/amplifytassel/src/app/components/Dashboard/DashboardPendingReqCard.js
+++ b/amplifytassel/src/app/components/Dashboard/DashboardPendingReqCard.js
@@ -7,6 +7,7 @@ import Chip from "@mui/material/Chip";
 import { Storage } from "aws-amplify";
 import EventNoteRoundedIcon from "@mui/icons-material/EventNoteRounded";
 import AccessibilityRoundedIcon from "@mui/icons-material/AccessibilityRounded";
+import PeopleIcon from "@mui/icons-material/People";
 
 import {
   CardContent,
@@ -21,6 +22,7 @@ import {
  */
 export default function DashboardPendingReqCard({ opportunity }) {
   const [banner, setBanner] = useState(null);
+  const [participants, setParticipants] = useState(0);
 
   const downloadFile = async () => {
     const img = await Storage.get(opportunity.bannerKey, {
@@ -32,6 +34,15 @@ export default function DashboardPendingReqCard({ opportunity }) {
   useEffect(() => {
     downloadFile();
   }, []);
+
+  useEffect(() => {
+    if (opportunity?.profilesJoined?.values) {
+      opportunity.profilesJoined.values
+        .then((result) => {
+          setParticipants(result.length);
+        })
+    }
+  }, [opportunity]);
 
   const navigate = useNavigate();
   const navigateToOpp = (oppid) => {
@@ -137,13 +148,16 @@ export default function DashboardPendingReqCard({ opportunity }) {
             height: "100%",
           }}
         >
-          <Typography
-            variant="body1"
-            fontWeight="bold"
-            sx={{ color: "var(--text-dark)" }}
-          >
-            {opportunity?.eventName}
-          </Typography>
+          <MuiBox sx={{ display: "flex" }}>
+            <Typography
+              variant="body1"
+              fontWeight="bold"
+              sx={{ color: "var(--text-dark)", marginRight: "10px" }}
+            >
+              {opportunity?.eventName}
+            </Typography>
+            <Chip label={participants} icon={<PeopleIcon />} size="small" />
+          </MuiBox>
           <Typography variant="body2" color="var(--text-gray)">
             <div className="flex-horizontal flex-flow-large flex-align-center">
               <EventNoteRoundedIcon sx={{ fontSize: "0.9rem" }} />

--- a/amplifytassel/src/app/components/Opportunities/OpportunitiesCard.js
+++ b/amplifytassel/src/app/components/Opportunities/OpportunitiesCard.js
@@ -16,9 +16,11 @@ import EditRoundedIcon from "@mui/icons-material/EditRounded";
 import EventNoteRoundedIcon from "@mui/icons-material/EventNoteRounded";
 import FmdGoodOutlinedIcon from "@mui/icons-material/FmdGoodOutlined";
 import TimerOutlinedIcon from "@mui/icons-material/TimerOutlined";
+import PeopleIcon from '@mui/icons-material/People';
 import { Modal, Tooltip } from "@mui/material";
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
+import Chip from "@mui/material/Chip";
 
 import useAuth from "../../util/AuthContext";
 import RequestModal from "../CustomComponents/RequestOpportunityModal";
@@ -257,6 +259,7 @@ export default function OpportunitiesCard({
   const [fileData, setFileData] = useState(null);
   const [fileDataURL, setFileDataURL] = useState(null);
   const { userProfile, setUserProfile } = useAuth();
+  const [participants, setParticipants] = useState(0);
 
   const { setShowConfettiAnimation, setShowStarAnimation } = useAnimation();
 
@@ -761,6 +764,12 @@ export default function OpportunitiesCard({
     getOpportunityCreator(opportunity);
     extractRoles(opportunity);
     extractKeywords(opportunity);
+    if (opportunity?.profilesJoined?.values) {
+      opportunity.profilesJoined.values
+        .then((result) => {
+          setParticipants(result.length);
+        })
+    }
   }, [opportunity]);
 
   useEffect(() => {
@@ -791,12 +800,16 @@ export default function OpportunitiesCard({
               to={`/Opportunity/${opportunity.id}`}
             >
               <MuiBox>
-                <h4
-                  className="text-dark ellipsis"
-                  aria-label={`Opportunity Card Title ${opportunity.eventName}`}
-                >
-                  {opportunity.eventName}
-                </h4>
+                <MuiBox sx={{ display: "flex" }}>
+                  <h4
+                    className="text-dark ellipsis"
+                    aria-label={`Opportunity Card Title ${opportunity.eventName}`}
+                    style={{ marginRight: "10px" }}
+                  >
+                    {opportunity.eventName}
+                  </h4>
+                  <Chip label={participants} icon={<PeopleIcon />} size="small" />
+                </MuiBox>
                 <div
                   className="flex-flow-large flex-align-center"
                   style={{ paddingTop: "0.5em" }}


### PR DESCRIPTION
I added participant count chips to the opportunity cards/thumbnails so people can see at a glance how many people have joined an opportunity.